### PR TITLE
Do not assign perks if the fetch failed

### DIFF
--- a/scripting/GFL-UserManagement.sp
+++ b/scripting/GFL-UserManagement.sp
@@ -225,7 +225,9 @@ public Action OnClientPreAdminCheck(int client) {
 }
 
 public void OnClientPostAdminFilter(int client) {
-	AssignPerks(client);
+	if (!g_bResponseFailed[client]) {
+		AssignPerks(client);
+	}
 }
 
 stock void AssignPerks(int client) {


### PR DESCRIPTION
Currently, the plugin will try to assign perks even if the request
fails. This means that it will try to apply whatever is in
`g_iClientGroup` which can lead to people receiving unintended
permissions.