### PR TITLE
Don't fetch perks for bots

### DIFF
--- a/scripting/GFL-UserManagement.sp
+++ b/scripting/GFL-UserManagement.sp
@@ -175,7 +175,7 @@ public void PerkJSONReceived(HTTPResponse response, any userID) {
 	// Check if the response errored out.
 	if (response.Status != HTTPStatus_OK) {
 		// Welp, fuck...
-		GFLCore_LogMessage("", "[GFL-UserManagement] PerkJSONReceived() :: Error with GET reqeust (Error code: %d, Steam ID: %s)", response.Status, steamID64);
+		GFLCore_LogMessage("", "[GFL-UserManagement] PerkJSONReceived() :: Error with GET request (Error code: %d, Steam ID: %s)", response.Status, steamID64);
 		g_bResponseFailed[client] = true;
 		if(g_bClientPreAdminChecked[client]) NotifyPostAdminCheck(client);
 		return;

--- a/scripting/GFL-UserManagement.sp
+++ b/scripting/GFL-UserManagement.sp
@@ -140,25 +140,25 @@ public void OnClientDisconnect(int client) {
 }
 
 public void OnClientAuthorized(int client, const char[] sAuth2) {
-	if (!IsFakeClient(client)) {
-		// Get their Steam ID 64.
-		char steamID64[64];
-		GetClientAuthId(client, AuthId_SteamID64, steamID64, sizeof(steamID64), true);
+	if (IsFakeClient(client)) return;
+	
+	// Get their Steam ID 64.
+	char steamID64[64];
+	GetClientAuthId(client, AuthId_SteamID64, steamID64, sizeof(steamID64), true);
 
-		// Format the GET string.
-		char path[256];
-		Format(path, sizeof(path), "%s?steamid=%s", g_sEndpoint, steamID64);
+	// Format the GET string.
+	char path[256];
+	Format(path, sizeof(path), "%s?steamid=%s", g_sEndpoint, steamID64);
 
-		// Set authentication header.
-		httpClient.SetHeader("Authorization", g_sToken);
+	// Set authentication header.
+	httpClient.SetHeader("Authorization", g_sToken);
 
-		// Execute the GET request.
-		httpClient.Get(path, PerkJSONReceived, GetClientUserId(client));
+	// Execute the GET request.
+	httpClient.Get(path, PerkJSONReceived, GetClientUserId(client));
 
-		// Debug.
-		if (g_bDebug) {
-			GFLCore_LogMessage("", "[GFL-UserManagement] OnClientAuthorized() :: Fetching perks for %L now...", client);
-		}
+	// Debug.
+	if (g_bDebug) {
+		GFLCore_LogMessage("", "[GFL-UserManagement] OnClientAuthorized() :: Fetching perks for %L now...", client);
 	}
 }
 

--- a/scripting/GFL-UserManagement.sp
+++ b/scripting/GFL-UserManagement.sp
@@ -140,23 +140,25 @@ public void OnClientDisconnect(int client) {
 }
 
 public void OnClientAuthorized(int client, const char[] sAuth2) {
-	// Get their Steam ID 64.
-	char steamID64[64];
-	GetClientAuthId(client, AuthId_SteamID64, steamID64, sizeof(steamID64), true);
+	if (!IsFakeClient(client)) {
+		// Get their Steam ID 64.
+		char steamID64[64];
+		GetClientAuthId(client, AuthId_SteamID64, steamID64, sizeof(steamID64), true);
 
-	// Format the GET string.
-	char path[256];
-	Format(path, sizeof(path), "%s?steamid=%s", g_sEndpoint, steamID64);
+		// Format the GET string.
+		char path[256];
+		Format(path, sizeof(path), "%s?steamid=%s", g_sEndpoint, steamID64);
 
-	// Set authentication header.
-	httpClient.SetHeader("Authorization", g_sToken);
+		// Set authentication header.
+		httpClient.SetHeader("Authorization", g_sToken);
 
-	// Execute the GET request.
-	httpClient.Get(path, PerkJSONReceived, GetClientUserId(client));
+		// Execute the GET request.
+		httpClient.Get(path, PerkJSONReceived, GetClientUserId(client));
 
-	// Debug.
-	if (g_bDebug) {
-		GFLCore_LogMessage("", "[GFL-UserManagement] OnClientAuthorized() :: Fetching perks for %L now...", client);
+		// Debug.
+		if (g_bDebug) {
+			GFLCore_LogMessage("", "[GFL-UserManagement] OnClientAuthorized() :: Fetching perks for %L now...", client);
+		}
 	}
 }
 

--- a/scripting/GFL-UserManagement.sp
+++ b/scripting/GFL-UserManagement.sp
@@ -122,7 +122,7 @@ public Action Timer_RebuildCache(Handle timer) {
 	ValidateGroups();
 
 	for(int client = 1; client <= MaxClients; client++) {
-		if(g_bClientPreAdminChecked[client] && g_iClientGroup[client] > 0) {
+		if(g_bClientPreAdminChecked[client] && g_iClientGroup[client] > 0 && !IsFakeClient(client)) {
 			if (g_bDebug) {
 				GFLCore_LogMessage("", "[GFL-UserManagement] Timer_RebuildCache() :: Assigning perks for %L since they are cached.", client);
 			}


### PR DESCRIPTION
Trying to fetch perks for bots is unnecessary, so this PR simply adds checks to prevent the plugin from doing so